### PR TITLE
add png save/visualize option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ eval/*.json
 pretrained_models/
 vis_result/
 *.pdf
+*.pkl
+.vector_cache
+data

--- a/settings.py
+++ b/settings.py
@@ -81,7 +81,8 @@ def parse_args():
                         help='plot graph if true')
     parser.add_argument('--visualize', action='store_true',
                         help='enable visualization')
-
+    parser.add_argument('--format', type=str, default='png',
+                        help='scene graph image format, pdf or png')
     args = parser.parse_args()
 
     return args


### PR DESCRIPTION
기존 scene graph를 창에 띄울 때 pdf 파일이 중구난방으로 여기저기 떠서 보기 힘들었는데,
이것을 해결하였습니다. pdf파일은 창 위치를 지정할 수 없어서 
우선 png 파일로 저장한 뒤 이를 다시 불러와서 지정한 위치에 plot하였습니다.